### PR TITLE
Use latest tasty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,29 @@
-# OS junk
-Thumbs.db
-.DS_Store
+dist
+dist-newstyle
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
 
-# Build artifacts
-dist/
-
-.*.swp
+/*.submodules
+/.stack-work/
+/.stack-work-*/
+/result
+/deps
+/data
+/corpus
+/*.json
+/*.json.ib
+/*.json.bp
+/snapshot.yaml
+/stack-ci.yaml

--- a/temporary-resourcet.cabal
+++ b/temporary-resourcet.cabal
@@ -57,7 +57,7 @@ test-suite test-temporary-resourcet
     base >=3 && <10,
     directory >=1.0,
     resourcet >=0.3 && <2,
-    tasty >=0.8 && <0.12,
+    tasty >=1.0 && <1.2,
     tasty-hunit >=0.8 && <0.12,
     temporary-resourcet,
     transformers >=0.2.0.0

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,27 +1,28 @@
 module Main where
 
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
-import Control.Monad ( liftM )
-import Control.Monad.IO.Class ( liftIO )
-import Control.Monad.Trans.Resource
-import System.Directory ( doesDirectoryExist, doesFileExist )
-import System.IO.Temp
+import           Control.Monad                (liftM)
+import           Control.Monad.IO.Class       (liftIO)
+import           Control.Monad.Trans.Resource
+import           System.Directory             (doesDirectoryExist,
+                                               doesFileExist)
+import           System.IO.Temp
 
 main :: IO ()
 main = defaultMain $ testGroup "temporary-resourcet"
     [ testGroup "createTempDirectory"
-        [ testCase "release" $ assert test_createTempDirectory_release
-        , testCase "runResourceT" $ assert test_createTempDirectory_runResourceT
+        [ testCase "release" $ test_createTempDirectory_release @? "Directory still exists"
+        , testCase "runResourceT" $ test_createTempDirectory_runResourceT @? "Directory still exists"
         ]
     , testGroup "openBinaryTempFile"
-        [ testCase "release" $ assert test_openBinaryTempFile_release
-        , testCase "runResourceT" $ assert test_openBinaryTempFile_runResourceT
+        [ testCase "release" $ test_openBinaryTempFile_release @? "File still exists"
+        , testCase "runResourceT" $ test_openBinaryTempFile_runResourceT @? "File still exists"
         ]
     , testGroup "openTempFile"
-        [ testCase "release" $ assert test_openTempFile_release
-        , testCase "runResourceT" $ assert test_openTempFile_runResourceT
+        [ testCase "release" $ test_openTempFile_release @? "File still exists"
+        , testCase "runResourceT" $ test_openTempFile_runResourceT @? "File still exists"
         ]
     ]
 


### PR DESCRIPTION
Bump `tasty` version to allow building against latest `nixpkgs`.

Could you please release a new version on Hackage?